### PR TITLE
Add basic Ollama support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,3 @@
 OPENAI_API_KEY=your_api_key
+# Set to your local Ollama endpoint to use a self-hosted model
+OLLAMA_BASE_URL=http://localhost:11434/v1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ There are two main patterns demonstrated:
 
 - This is a Next.js typescript app. Install dependencies with `npm i`.
 - Add your `OPENAI_API_KEY` to your env. Either add it to your `.bash_profile` or equivalent, or copy `.env.sample` to `.env` and add it there.
+- To use [Ollama](https://ollama.ai/) or another OpenAI-compatible server, set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`). When `OLLAMA_BASE_URL` is set the `OPENAI_API_KEY` value will be ignored. If you see an invalid API key error after updating your environment, restart the dev server so Next.js picks up the changes.
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.

--- a/src/app/api/responses/route.ts
+++ b/src/app/api/responses/route.ts
@@ -5,6 +5,21 @@ import OpenAI from 'openai';
 export async function POST(req: NextRequest) {
   const body = await req.json();
 
+  if (!process.env.OPENAI_API_KEY && !process.env.OLLAMA_BASE_URL) {
+    return NextResponse.json(
+      { error: 'Server misconfigured: set OPENAI_API_KEY or OLLAMA_BASE_URL' },
+      { status: 500 },
+    );
+  }
+
+  if (process.env.OLLAMA_BASE_URL) {
+    const openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY || 'ollama',
+      baseURL: process.env.OLLAMA_BASE_URL,
+    });
+    return await ollamaResponse(openai, body);
+  }
+
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
   if (body.text?.format?.type === 'json_schema') {
@@ -38,6 +53,45 @@ async function textResponse(openai: OpenAI, body: any) {
     return NextResponse.json(response);
   } catch (err: any) {
     console.error('responses proxy error', err);
+    return NextResponse.json({ error: 'failed' }, { status: 500 });
+  }
+}
+
+async function ollamaResponse(openai: OpenAI, body: any) {
+  try {
+    const messages = (body.input || [])
+      .filter((item: any) => item.type === 'message')
+      .map((item: any) => ({ role: item.role, content: item.content }));
+
+    const resp = await openai.chat.completions.create({
+      model: body.model,
+      messages,
+      tools: body.tools,
+      stream: false,
+    } as any);
+
+    const choice = resp.choices?.[0]?.message;
+    const output: any[] = [];
+
+    for (const tc of choice?.tool_calls || []) {
+      output.push({
+        type: 'function_call',
+        call_id: tc.id,
+        name: tc.function.name,
+        arguments: tc.function.arguments,
+      });
+    }
+
+    if (choice?.content) {
+      output.push({
+        type: 'message',
+        content: [{ type: 'output_text', text: choice.content }],
+      });
+    }
+
+    return NextResponse.json({ output });
+  } catch (err: any) {
+    console.error('ollama proxy error', err);
     return NextResponse.json({ error: 'failed' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- add `OLLAMA_BASE_URL` example to `.env.sample`
- document local Ollama URL in README
- support optional Ollama endpoint in `/api/responses` proxy
- clarify Ollama usage instructions and handle missing credentials

## Testing
- `npm run lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843064286ec83278f9576a9a9100535