### PR TITLE
Switch to Ollama only

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,2 @@
-OPENAI_API_KEY=your_api_key
-# Set to your local Ollama endpoint to use a self-hosted model
+# Base URL for your local Ollama server
 OLLAMA_BASE_URL=http://localhost:11434/v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Realtime API Agents Demo
 
-This is a demonstration of more advanced patterns for voice agents, using the OpenAI Realtime API and the OpenAI Agents SDK. 
+This demo showcases advanced patterns for voice agents using the OpenAI Agents SDK and a local Ollama server.
 
 ** NOTE:** For a version that does not use the OpenAI Agents SDK, see the [branch without-agents-sdk](https://github.com/openai/openai-realtime-agents/tree/without-agents-sdk).
 
@@ -11,8 +11,7 @@ There are two main patterns demonstrated:
 ## Setup
 
 - This is a Next.js typescript app. Install dependencies with `npm i`.
-- Add your `OPENAI_API_KEY` to your env. Either add it to your `.bash_profile` or equivalent, or copy `.env.sample` to `.env` and add it there.
-- To use [Ollama](https://ollama.ai/) or another OpenAI-compatible server, set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`). When `OLLAMA_BASE_URL` is set the `OPENAI_API_KEY` value will be ignored. If you see an invalid API key error after updating your environment, restart the dev server so Next.js picks up the changes.
+- Run [Ollama](https://ollama.ai/) locally and set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`).
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.

--- a/src/app/api/responses/route.ts
+++ b/src/app/api/responses/route.ts
@@ -1,78 +1,41 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
 
-// Proxy endpoint for the OpenAI Responses API
+// Proxy endpoint for Ollama
 export async function POST(req: NextRequest) {
   const body = await req.json();
 
-
-  if (!process.env.OPENAI_API_KEY && !process.env.OLLAMA_BASE_URL) {
+  if (!process.env.OLLAMA_BASE_URL) {
     return NextResponse.json(
-      { error: 'Server misconfigured: set OPENAI_API_KEY or OLLAMA_BASE_URL' },
+      { error: 'Server misconfigured: set OLLAMA_BASE_URL' },
       { status: 500 },
     );
   }
 
-
-  if (process.env.OLLAMA_BASE_URL) {
-    const openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY || 'ollama',
-      baseURL: process.env.OLLAMA_BASE_URL,
-    });
-    return await ollamaResponse(openai, body);
-  }
-
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
-  if (body.text?.format?.type === 'json_schema') {
-    return await structuredResponse(openai, body);
-  } else {
-    return await textResponse(openai, body);
-  }
+  return await ollamaResponse(body);
 }
 
-async function structuredResponse(openai: OpenAI, body: any) {
-  try {
-    const response = await openai.responses.parse({
-      ...(body as any),
-      stream: false,
-    } as any);
-
-    return NextResponse.json(response);
-  } catch (err: any) {
-    console.error('responses proxy error', err);
-    return NextResponse.json({ error: 'failed' }, { status: 500 }); 
-  }
-}
-
-async function textResponse(openai: OpenAI, body: any) {
-  try {
-    const response = await openai.responses.create({
-      ...(body as any),
-      stream: false,
-    } as any);
-
-    return NextResponse.json(response);
-  } catch (err: any) {
-    console.error('responses proxy error', err);
-    return NextResponse.json({ error: 'failed' }, { status: 500 });
-  }
-}
-
-async function ollamaResponse(openai: OpenAI, body: any) {
+async function ollamaResponse(body: any) {
   try {
     const messages = (body.input || [])
       .filter((item: any) => item.type === 'message')
       .map((item: any) => ({ role: item.role, content: item.content }));
 
-    const resp = await openai.chat.completions.create({
-      model: body.model,
-      messages,
-      tools: body.tools,
-      stream: false,
-    } as any);
+    const resp = await fetch(
+      `${process.env.OLLAMA_BASE_URL}/chat/completions`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: body.model,
+          messages,
+          tools: body.tools,
+          stream: false,
+        }),
+      },
+    );
 
-    const choice = resp.choices?.[0]?.message;
+    const data = await resp.json();
+    const choice = data.choices?.[0]?.message;
     const output: any[] = [];
 
     for (const tc of choice?.tool_calls || []) {

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,28 +1,8 @@
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  try {
-    const response = await fetch(
-      "https://api.openai.com/v1/realtime/sessions",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "gpt-4o-realtime-preview-2024-12-17",
-          // model: "gpt-4o-mini-realtime-preview-2024-12-17",
-        }),
-      }
-    );
-    const data = await response.json();
-    return NextResponse.json(data);
-  } catch (error) {
-    console.error("Error in /session:", error);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 }
-    );
-  }
+  return NextResponse.json(
+    { error: "Realtime sessions are not supported with Ollama" },
+    { status: 400 }
+  );
 }


### PR DESCRIPTION
## Summary
- drop OpenAI key and instructions from README and `.env.sample`
- remove calls to OpenAI from session and responses routes
- use local Ollama server exclusively

## Testing
- `npm run lint` *(fails: unused vars, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68430c5cdf7883279cba1062af24a568