### PR TITLE
Restore OpenAI realtime session support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
+OPENAI_API_KEY=your_api_key
 # Base URL for your local Ollama server
 OLLAMA_BASE_URL=http://localhost:11434/v1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ There are two main patterns demonstrated:
 ## Setup
 
 - This is a Next.js typescript app. Install dependencies with `npm i`.
-- Run [Ollama](https://ollama.ai/) locally and set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`).
+- Add your `OPENAI_API_KEY` to the environment. You can copy `.env.sample` to `.env` and fill in your key.
+- To use [Ollama](https://ollama.ai/) or another OpenAI-compatible server, set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`). When `OLLAMA_BASE_URL` is set the `OPENAI_API_KEY` value will be ignored.
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.


### PR DESCRIPTION
## Summary
- reinstate OpenAI API usage for realtime sessions and responses
- mention OPENAI_API_KEY again in README
- add OPENAI_API_KEY to `.env.sample`

## Testing
- `npm run lint` *(fails: 'eventNameSuffix' is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68431298d07c8327b6a4e8203da92859