### PR TITLE
Allow realtime with Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ There are two main patterns demonstrated:
 
 - This is a Next.js typescript app. Install dependencies with `npm i`.
 - Add your `OPENAI_API_KEY` to the environment. You can copy `.env.sample` to `.env` and fill in your key.
-- To use [Ollama](https://ollama.ai/) or another OpenAI-compatible server, set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`). When `OLLAMA_BASE_URL` is set the `OPENAI_API_KEY` value will be ignored.
+- To use [Ollama](https://ollama.ai/) or another OpenAI-compatible server, set `OLLAMA_BASE_URL` to its base URL (for example `http://localhost:11434/v1`).
+  The `OPENAI_API_KEY` is still required for realtime sessions.
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,13 +1,6 @@
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  if (process.env.OLLAMA_BASE_URL) {
-    return NextResponse.json(
-      { error: "Realtime sessions are not supported with Ollama" },
-      { status: 400 }
-    );
-  }
-
   if (!process.env.OPENAI_API_KEY) {
     return NextResponse.json(
       { error: "Server misconfigured: set OPENAI_API_KEY" },


### PR DESCRIPTION
## Summary
- update README instructions for Ollama
- allow `/api/session` to create realtime sessions even if `OLLAMA_BASE_URL` is set

## Testing
- `npm install`
- `npm run lint` *(fails: several eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843148066bc8327a6d2147c851ec80e